### PR TITLE
fix: Remove non-installed Tailwind plugins to fix build error

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,8 +23,5 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/typography'),
-  ],
+  plugins: [],
 }


### PR DESCRIPTION
Esta corrección resuelve el error de build que estaba impidiendo el despliegue de ClearPath.

**Problema:**
- El build fallaba porque `tailwind.config.js` requería plugins no instalados (`@tailwindcss/forms` y `@tailwindcss/typography`)
- - Esto causaba errores en webpack al procesar los archivos CSS
**Solución:**
- Removidos los plugins no instalados del array `plugins`
- - Configuración simplificada que funciona con las dependencias actuales
**Resultado esperado:**
- Build exitoso en Vercel
- - ClearPath funcionando en producción con Next.js + Tailwind CSS